### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,4 +1,6 @@
 name: Code Quality
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ComfyAssets/ComfyUI-KikoTools/security/code-scanning/10](https://github.com/ComfyAssets/ComfyUI-KikoTools/security/code-scanning/10)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/code-quality.yml`. The block should be placed at the root level (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. The minimal starting point is `contents: read`, which allows jobs to read repository contents but not modify them. If any job requires additional permissions (e.g., to create pull requests), those can be added as needed, but for this workflow, `contents: read` is sufficient. No changes to the steps or job definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
