### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:
@@ -8,6 +11,8 @@ on:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ComfyAssets/ComfyUI-KikoTools/security/code-scanning/1](https://github.com/ComfyAssets/ComfyUI-KikoTools/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the workflow. The best approach is to set a global `permissions` block at the top level of the workflow, restricting permissions to `contents: read` (the minimal safe default). Then, for jobs that require additional permissions (such as `create-release`, which needs to create a release and upload assets), we should override the permissions block for that job, granting only the necessary write permissions (typically `contents: write`). The `notify-community` job does not require any write permissions, so it can inherit the global minimal permissions.

Specifically:
- Add a top-level `permissions` block with `contents: read`.
- Add a `permissions` block to the `create-release` job with `contents: write`.
- No changes are needed for the `notify-community` job.

All changes are to be made in `.github/workflows/release.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
