### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]


### PR DESCRIPTION
Potential fix for [https://github.com/ComfyAssets/ComfyUI-KikoTools/security/code-scanning/8](https://github.com/ComfyAssets/ComfyUI-KikoTools/security/code-scanning/8)

To fix the problem, add an explicit `permissions` block to the workflow file `.github/workflows/tests.yml`. The block should be placed at the top level (before or after the `on:` key), so it applies to all jobs in the workflow. Since all jobs only require read access to repository contents, set `contents: read` as the minimal required permission. This change ensures that the GITHUB_TOKEN used by the workflow has only read access, adhering to the principle of least privilege and improving security. No additional imports or code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
