### PR TITLE
Potential fix for code scanning alert no. 14: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/kikotools/tools/model_downloader/civitai.py
+++ b/kikotools/tools/model_downloader/civitai.py
@@ -136,8 +136,15 @@ class CivitAIDownloader(BaseDownloader):
         # Validate output path
         self.validate_output_path(output_path)
 
+        # Validate that URL is from civitai.com domain
+        parsed_url = urlparse(url)
+        if parsed_url.netloc not in ("civitai.com", "www.civitai.com"):
+            raise ValueError(
+                f"Invalid URL: Only civitai.com URLs are supported, got {parsed_url.netloc}"
+            )
+
         # Convert web URL to API URL if needed
-        if "civitai.com" in url and "/api/download/models/" not in url:
+        if "/api/download/models/" not in url:
             ids = self._parse_civitai_url(url)
 
             # If we have a version ID, use it directly

--- a/kikotools/tools/model_downloader/detector.py
+++ b/kikotools/tools/model_downloader/detector.py
@@ -67,7 +67,8 @@ class URLDetector:
         Returns:
             True if CivitAI URL
         """
-        if "civitai.com" not in parsed.netloc:
+        # Validate exact domain match to prevent subdomain attacks
+        if parsed.netloc not in ("civitai.com", "www.civitai.com"):
             return False
 
         # Check for API download endpoint
@@ -90,8 +91,15 @@ class URLDetector:
         Returns:
             True if HuggingFace URL
         """
-        # Check main domain and CDN
-        if "huggingface.co" in parsed.netloc:
+        # Validate exact domain match to prevent subdomain attacks
+        # Support both main domain and CDN domains
+        allowed_domains = (
+            "huggingface.co",
+            "www.huggingface.co",
+            "cdn.huggingface.co",
+            "cdn-lfs.huggingface.co",
+        )
+        if parsed.netloc in allowed_domains:
             return True
 
         return False

--- a/kikotools/tools/model_downloader/node.py
+++ b/kikotools/tools/model_downloader/node.py
@@ -148,7 +148,7 @@ class ModelDownloaderNode(ComfyAssetsBaseNode):
         input_str = (
             f"{url}|{save_path}|{filename}|{api_token}|{force_download}|{time.time()}"
         )
-        return hashlib.md5(input_str.encode()).hexdigest()
+        return hashlib.sha256(input_str.encode()).hexdigest()
 
 
 # Node display name

--- a/kikotools/tools/model_downloader/node.py
+++ b/kikotools/tools/model_downloader/node.py
@@ -144,10 +144,10 @@ class ModelDownloaderNode(ComfyAssetsBaseNode):
         import time
         import hashlib
 
-        # Create a unique hash based on inputs and current time
-        input_str = (
-            f"{url}|{save_path}|{filename}|{api_token}|{force_download}|{time.time()}"
-        )
+        # Create a unique hash based on non-sensitive inputs and current time
+        # Note: api_token is excluded to avoid sensitive data in hash
+        # The token doesn't affect cache invalidation - URL changes are sufficient
+        input_str = f"{url}|{save_path}|{filename}|{force_download}|{time.time()}"
         return hashlib.sha256(input_str.encode()).hexdigest()
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/ComfyAssets/ComfyUI-KikoTools/security/code-scanning/14](https://github.com/ComfyAssets/ComfyUI-KikoTools/security/code-scanning/14)

To fix the problem, replace the use of `hashlib.md5` with a strong hash function such as `hashlib.sha256` in kikotools/tools/model_downloader/node.py, specifically in the IS_CHANGED class method (around lines 147–151). Ensure the hash function is suitable for the purpose (unique per set of inputs) but is not vulnerable to known attacks. Since the hash is used for re-evaluation logic, we do not need a password hasher, just a collision-resistant cryptographic hash. No additional imports are necessary as `hashlib.sha256` is already available in the Python standard library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
